### PR TITLE
Add error messages indicating M1 builds and Linux builds are not supported

### DIFF
--- a/Formula/ironfish.rb
+++ b/Formula/ironfish.rb
@@ -16,6 +16,18 @@ class Ironfish < Formula
   depends_on "node@16"
 
   def install
+    if OS.linux?
+      odie "Homebrew builds are not yet supported on Linux. " \
+           "However, you can build from source by following the steps in our GitHub README: " \
+           "https://github.com/iron-fish/ironfish#install"
+    end
+
+    if Hardware::CPU.arm?
+      odie "Homebrew builds are not yet supported on M1/Apple Silicon. " \
+           "However, you can build from source by following the steps in our GitHub README: " \
+           "https://github.com/iron-fish/ironfish#install"
+    end
+
     inreplace "bin/ironfish", /^CLIENT_HOME=/,
 "export IRONFISH_OCLIF_CLIENT_HOME=#{lib/"client"}/ironfish-cli\nCLIENT_HOME="
     inreplace "bin/ironfish", "\"$DIR/node\"", "#{Formula["node@16"].bin}/node"

--- a/Formula/ironfishbeta.rb
+++ b/Formula/ironfishbeta.rb
@@ -16,6 +16,18 @@ class Ironfishbeta < Formula
   depends_on "node@16"
 
   def install
+    if OS.linux?
+      odie "Homebrew builds are not yet supported on Linux. " \
+           "However, you can build from source by following the steps in our GitHub README: " \
+           "https://github.com/iron-fish/ironfish#install"
+    end
+
+    if Hardware::CPU.arm?
+      odie "Homebrew builds are not yet supported on M1/Apple Silicon. " \
+           "However, you can build from source by following the steps in our GitHub README: " \
+           "https://github.com/iron-fish/ironfish#install"
+    end
+
     inreplace "bin/ironfish", /^CLIENT_HOME=/,
 "export IRONFISH_OCLIF_CLIENT_HOME=#{lib/"client"}/ironfish-cli\nCLIENT_HOME="
     inreplace "bin/ironfish", "\"$DIR/node\"", "#{Formula["node@16"].bin}/node"


### PR DESCRIPTION
We've seen several issues where M1 users attempt to install our Homebrew package, then run into errors because our prebuilds are done on Intel macs only. This adds an error to the package installation process until we fix the issue by doing multiple prebuilds or using the Homebrew bottle system.
